### PR TITLE
Fix tagging to prevent inheritence from base image

### DIFF
--- a/Containerfile.rhtap
+++ b/Containerfile.rhtap
@@ -29,6 +29,7 @@ LABEL name="ocm-example-service" \
       vendor="Red Hat" \
       version="0.0.1" \
       summary="OCM Example Service API" \
+      description="OCM Example Service API" \
       io.k8s.description="OCM Example Service API" \
       io.k8s.display-name="RH-TREX" \
       io.openshift.tags="rh-trex"

--- a/Containerfile.rhtap
+++ b/Containerfile.rhtap
@@ -29,4 +29,6 @@ LABEL name="ocm-example-service" \
       vendor="Red Hat" \
       version="0.0.1" \
       summary="OCM Example Service API" \
-      description="OCM Example Service API"
+      io.k8s.description="OCM Example Service API" \
+      io.k8s.display-name="RH-TREX" \
+      io.openshift.tags="rh-trex"


### PR DESCRIPTION
## Summary of Changes

To pass RHTAP security scans in Enterprise Contract, we can't inherit certain tags form the base image, this PR sets those flags in the Containerfile to prevent inheritance.  