### PR TITLE
Tweak the locks disabled test to make sure that we see a non-blocking scenario

### DIFF
--- a/test/integration/dinosaurs_test.go
+++ b/test/integration/dinosaurs_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/openshift-online/rh-trex/pkg/api"
 	"github.com/openshift-online/rh-trex/pkg/dao"
 	"github.com/openshift-online/rh-trex/pkg/services"
@@ -268,6 +267,6 @@ func TestUpdateDinosaurWithRacingRequests_WithoutLock(t *testing.T) {
 	}
 
 	// the dinosaur patch request is not protected by the advisory lock, so there will likely be more then one update captured
-	glog.Infof("Updated Count: %v\n", updatedCount)
+	t.Logf("Updated Count: %v\n", updatedCount)
 	Expect(updatedCount > 1).To(BeTrue())
 }

--- a/test/integration/dinosaurs_test.go
+++ b/test/integration/dinosaurs_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/glog"
 	"github.com/openshift-online/rh-trex/pkg/api"
 	"github.com/openshift-online/rh-trex/pkg/dao"
 	"github.com/openshift-online/rh-trex/pkg/services"
@@ -266,6 +267,7 @@ func TestUpdateDinosaurWithRacingRequests_WithoutLock(t *testing.T) {
 		}
 	}
 
-	// the dinosaur patch request is not protected by the advisory lock, so there should be at least one update
-	Expect(updatedCount >= 1).To(BeTrue())
+	// the dinosaur patch request is not protected by the advisory lock, so there will likely be more then one update captured
+	glog.Infof("Updated Count: %v\n", updatedCount)
+	Expect(updatedCount > 1).To(BeTrue())
 }


### PR DESCRIPTION
Adjust the test to be more realistic and expose the problems with non-blocking.

1. This test may fail once in a while depending on the timing. I ran the test about 50x without see just a single update.
If this test fails once in a while, we could go back to >= 1, and as long as there is the log message to view, so you can see the non-blocked update occurring.