### PR TITLE
move foreign key creation function to migrations.

### DIFF
--- a/pkg/db/migrations.go
+++ b/pkg/db/migrations.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/go-gormigrate/gormigrate/v2"
 	"github.com/golang/glog"
@@ -37,26 +36,4 @@ func MigrateTo(sessionFactory SessionFactory, migrationID string) {
 
 func newGormigrate(g2 *gorm.DB) *gormigrate.Gormigrate {
 	return gormigrate.New(g2, gormigrate.DefaultOptions, migrations.MigrationList)
-}
-
-type fkMigration struct {
-	Model     string
-	Dest      string
-	Field     string
-	Reference string
-}
-
-func CreateFK(g2 *gorm.DB, fks ...fkMigration) error {
-	var query = `ALTER TABLE %s ADD CONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s ON DELETE RESTRICT ON UPDATE RESTRICT;`
-	var drop = `ALTER TABLE %s DROP CONSTRAINT IF EXISTS %s;`
-
-	for _, fk := range fks {
-		name := fmt.Sprintf("fk_%s_%s", fk.Model, fk.Dest)
-
-		g2.Exec(fmt.Sprintf(drop, fk.Model, name))
-		if err := g2.Exec(fmt.Sprintf(query, fk.Model, name, fk.Field, fk.Reference)).Error; err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/pkg/db/migrations/migration_structs.go
+++ b/pkg/db/migrations/migration_structs.go
@@ -1,6 +1,7 @@
 package migrations
 
 import (
+	"fmt"
 	"time"
 
 	"gorm.io/gorm"
@@ -35,4 +36,26 @@ type Model struct {
 	CreatedAt time.Time
 	UpdatedAt time.Time
 	DeletedAt gorm.DeletedAt `gorm:"index"`
+}
+
+type fkMigration struct {
+	Model     string
+	Dest      string
+	Field     string
+	Reference string
+}
+
+func CreateFK(g2 *gorm.DB, fks ...fkMigration) error {
+	var query = `ALTER TABLE %s ADD CONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s ON DELETE RESTRICT ON UPDATE RESTRICT;`
+	var drop = `ALTER TABLE %s DROP CONSTRAINT IF EXISTS %s;`
+
+	for _, fk := range fks {
+		name := fmt.Sprintf("fk_%s_%s", fk.Model, fk.Dest)
+
+		g2.Exec(fmt.Sprintf(drop, fk.Model, name))
+		if err := g2.Exec(fmt.Sprintf(query, fk.Model, name, fk.Field, fk.Reference)).Error; err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Move the `CreateFK` function and its related `fkMigration` struct from the `pkg/db` directory to `pkg/db/migrations` to resolve potential cyclic dependencies, so that it can be used by the db migration instance.