### PR TITLE
Resolve several minor issues with generator script

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -204,6 +204,12 @@ components:
           type: string
         href:
           type: string
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
     List:
       type: object
       properties:

--- a/pkg/api/presenters/time.go
+++ b/pkg/api/presenters/time.go
@@ -1,0 +1,14 @@
+package presenters
+
+import (
+	"time"
+
+	"github.com/openshift-online/rh-trex/pkg/util"
+)
+
+func PresentTime(t time.Time) *time.Time {
+	if t.IsZero() {
+		return util.ToPtr(time.Time{})
+	}
+	return util.ToPtr(t.Round(time.Microsecond))
+}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -5,6 +5,34 @@ import (
 	"fmt"
 )
 
+// ToPtr returns a pointer copy of value.
+func ToPtr[T any](v T) *T {
+	return &v
+}
+
+// FromPtr returns the pointer value or empty.
+func FromPtr[T any](v *T) T {
+	if v == nil {
+		return Empty[T]()
+	}
+	return *v
+}
+
+// FromEmptyPtr emulates ToPtr(FromPtr(x)) sequence
+func FromEmptyPtr[T any](v *T) *T {
+	if v == nil {
+		x := Empty[T]()
+		return &x
+	}
+	return v
+}
+
+// Empty returns an empty value of type T.
+func Empty[T any]() T {
+	var zero T
+	return zero
+}
+
 func EmptyStringToNil(a string) *string {
 	if a == "" {
 		return nil

--- a/scripts/generator.go
+++ b/scripts/generator.go
@@ -94,7 +94,7 @@ func main() {
 			"generate-test-factories": fmt.Sprintf("test/factories/%s.go", k.KindLowerPlural),
 			"generate-test":           fmt.Sprintf("test/integration/%s_test.go", k.KindLowerPlural),
 			"generate-services":       fmt.Sprintf("pkg/%s/%s.go", nm, k.KindLowerSingular),
-			"generate-servicelocator": fmt.Sprintf("cmd/ensemble/environments/locator_%s.go", k.KindLowerSingular),
+			"generate-servicelocator": fmt.Sprintf("cmd/trex/environments/locator_%s.go", k.KindLowerSingular),
 		}
 
 		outputPath, ok := outputPaths["generate-"+nm]

--- a/templates/generate-handlers.txt
+++ b/templates/generate-handlers.txt
@@ -53,9 +53,7 @@ func (h {{.KindLowerSingular}}Handler) Patch(w http.ResponseWriter, r *http.Requ
 
 	cfg := &handlerConfig{
 		&patch,
-		[]validate{
-			validate{{.Kind}}Patch(&patch),
-		},
+		[]validate{},
 		func() (interface{}, *errors.ServiceError) {
 			ctx := r.Context()
 			id := mux.Vars(r)["id"]

--- a/templates/generate-presenters.txt
+++ b/templates/generate-presenters.txt
@@ -1,9 +1,9 @@
 package presenters
 
 import (
-	"gitlab.cee.redhat.com/ocm/ensemble/pkg/api"
-	"gitlab.cee.redhat.com/ocm/ensemble/pkg/api/openapi"
-	"gitlab.cee.redhat.com/ocm/ensemble/pkg/util"
+	"github.com/openshift-online/rh-trex/pkg/api"
+	"github.com/openshift-online/rh-trex/pkg/api/openapi"
+	"github.com/openshift-online/rh-trex/pkg/util"
 )
 
 func Convert{{.Kind}}({{.KindLowerSingular}} openapi.{{.Kind}}) *api.{{.Kind}} {

--- a/templates/generate-servicelocator.txt
+++ b/templates/generate-servicelocator.txt
@@ -1,8 +1,8 @@
 package environments
 
 import (
-	"gitlab.cee.redhat.com/ocm/ensemble/pkg/dao"
-	"gitlab.cee.redhat.com/ocm/ensemble/pkg/services"
+	"github.com/openshift-online/rh-trex/pkg/dao"
+	"github.com/openshift-online/rh-trex/pkg/services"
 )
 
 type {{.Kind}}ServiceLocator func() services.{{.Kind}}Service

--- a/templates/generate-test-factories.txt
+++ b/templates/generate-test-factories.txt
@@ -2,8 +2,8 @@ package factories
 
 import (
 	"context"
-	"gitlab.cee.redhat.com/ocm/ensemble/cmd/ensemble/environments"
-	"gitlab.cee.redhat.com/ocm/ensemble/pkg/api"
+	"github.com/openshift-online/rh-trex/cmd/ensemble/environments"
+	"github.com/openshift-online/rh-trex/pkg/api"
 )
 
 func (f *Factories) New{{.Kind}}(id string) (*api.{{.Kind}}, error) {

--- a/templates/generate-test-factories.txt
+++ b/templates/generate-test-factories.txt
@@ -2,7 +2,7 @@ package factories
 
 import (
 	"context"
-	"github.com/openshift-online/rh-trex/cmd/ensemble/environments"
+	"github.com/openshift-online/rh-trex/cmd/trex/environments"
 	"github.com/openshift-online/rh-trex/pkg/api"
 )
 


### PR DESCRIPTION
Resolves the following problems:
- Adds the created_at and updated_at metadata fields to the OpenAPI spec parent 
- Removes a validation method added to handlers that is not generated
- Adds missing presenter helper "PresentTime"
- Removes references to the "ensemble" project
- Resolves imports to import from the correct github link