### PR TITLE
fix: removes 'dino' references in favor of KindLowerSingular

### DIFF
--- a/templates/generate-handlers.txt
+++ b/templates/generate-handlers.txt
@@ -35,12 +35,12 @@ func (h {{.KindLowerSingular}}Handler) Create(w http.ResponseWriter, r *http.Req
 		},
 		func() (interface{}, *errors.ServiceError) {
 			ctx := r.Context()
-			dino := presenters.Convert{{.Kind}}({{.KindLowerSingular}})
-			dino, err := h.{{.KindLowerSingular}}.Create(ctx, dino)
+			{{.KindLowerSingular}}Model := presenters.Convert{{.Kind}}({{.KindLowerSingular}})
+			{{.KindLowerSingular}}Model, err := h.{{.KindLowerSingular}}.Create(ctx, {{.KindLowerSingular}}Model)
 			if err != nil {
 				return nil, err
 			}
-			return presenters.Present{{.Kind}}(dino), nil
+			return presenters.Present{{.Kind}}({{.KindLowerSingular}}Model), nil
 		},
 		handleError,
 	}
@@ -64,11 +64,11 @@ func (h {{.KindLowerSingular}}Handler) Patch(w http.ResponseWriter, r *http.Requ
 
             //patch a field
 
-			dino, err := h.{{.KindLowerSingular}}.Replace(ctx, found)
+			{{.KindLowerSingular}}Model, err := h.{{.KindLowerSingular}}.Replace(ctx, found)
 			if err != nil {
 				return nil, err
 			}
-			return presenters.Present{{.Kind}}(dino), nil
+			return presenters.Present{{.Kind}}({{.KindLowerSingular}}Model), nil
 		},
 		handleError,
 	}
@@ -87,7 +87,7 @@ func (h {{.KindLowerSingular}}Handler) List(w http.ResponseWriter, r *http.Reque
 			if err != nil {
 				return nil, err
 			}
-			dinoList := openapi.{{.Kind}}List{
+			{{.KindLowerSingular}}List := openapi.{{.Kind}}List{
 				Kind:  "{{.Kind}}List",
 				Page:  int32(paging.Page),
 				Size:  int32(paging.Size),
@@ -95,18 +95,18 @@ func (h {{.KindLowerSingular}}Handler) List(w http.ResponseWriter, r *http.Reque
 				Items: []openapi.{{.Kind}}{},
 			}
 
-			for _, dino := range {{.KindLowerPlural}} {
-				converted := presenters.Present{{.Kind}}(&dino)
-				dinoList.Items = append(dinoList.Items, converted)
+			for _, {{.KindLowerSingular}} := range {{.KindLowerPlural}} {
+				converted := presenters.Present{{.Kind}}(&{{.KindLowerSingular}})
+				{{.KindLowerSingular}}List.Items = append({{.KindLowerSingular}}List.Items, converted)
 			}
 			if listArgs.Fields != nil {
-				filteredItems, err := presenters.SliceFilter(listArgs.Fields, dinoList.Items)
+				filteredItems, err := presenters.SliceFilter(listArgs.Fields, {{.KindLowerSingular}}List.Items)
 				if err != nil {
 					return nil, err
 				}
 				return filteredItems, nil
 			}
-			return dinoList, nil
+			return {{.KindLowerSingular}}List, nil
 		},
 	}
 

--- a/templates/generate-mock.txt
+++ b/templates/generate-mock.txt
@@ -21,9 +21,9 @@ func New{{.Kind}}Dao() *{{.KindLowerSingular}}DaoMock {
 }
 
 func (d *{{.KindLowerSingular}}DaoMock) Get(ctx context.Context, id string) (*api.{{.Kind}}, error) {
-	for _, dino := range d.{{.KindLowerPlural}} {
-		if dino.ID == id {
-			return dino, nil
+	for _, {{.KindLowerSingular}} := range d.{{.KindLowerPlural}} {
+		if {{.KindLowerSingular}}.ID == id {
+			return {{.KindLowerSingular}}, nil
 		}
 	}
 	return nil, gorm.ErrRecordNotFound

--- a/templates/generate-test.txt
+++ b/templates/generate-test.txt
@@ -29,18 +29,18 @@ func Test{{.Kind}}Get(t *testing.T) {
 	Expect(err).To(HaveOccurred(), "Expected 404")
 	Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
 
-	dino, err := h.Factories.New{{.Kind}}(h.NewID())
+	{{.KindLowerSingular}}Model, err := h.Factories.New{{.Kind}}(h.NewID())
     Expect(err).NotTo(HaveOccurred())
 
-	{{.KindLowerSingular}}, resp, err := client.DefaultApi.ApiRhTrexV1{{.Kind}}sIdGet(ctx, dino.ID).Execute()
+	{{.KindLowerSingular}}Output, resp, err := client.DefaultApi.ApiRhTrexV1{{.Kind}}sIdGet(ctx, {{.KindLowerSingular}}Model.ID).Execute()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
-	Expect(*{{.KindLowerSingular}}.Id).To(Equal(dino.ID), "found object does not match test object")
-	Expect(*{{.KindLowerSingular}}.Kind).To(Equal("{{.Kind}}"))
-	Expect(*{{.KindLowerSingular}}.Href).To(Equal(fmt.Sprintf("/api/rh-trex/v1/{{.KindLowerPlural}}/%s", dino.ID)))
-	Expect(*{{.KindLowerSingular}}.CreatedAt).To(BeTemporally("~", dino.CreatedAt))
-	Expect(*{{.KindLowerSingular}}.UpdatedAt).To(BeTemporally("~", dino.UpdatedAt))
+	Expect(*{{.KindLowerSingular}}Output.Id).To(Equal({{.KindLowerSingular}}Model.ID), "found object does not match test object")
+	Expect(*{{.KindLowerSingular}}Output.Kind).To(Equal("{{.Kind}}"))
+	Expect(*{{.KindLowerSingular}}Output.Href).To(Equal(fmt.Sprintf("/api/rh-trex/v1/{{.KindLowerPlural}}/%s", {{.KindLowerSingular}}Model.ID)))
+	Expect(*{{.KindLowerSingular}}Output.CreatedAt).To(BeTemporally("~", {{.KindLowerSingular}}Model.CreatedAt))
+	Expect(*{{.KindLowerSingular}}Output.UpdatedAt).To(BeTemporally("~", {{.KindLowerSingular}}Model.UpdatedAt))
 }
 
 func Test{{.Kind}}Post(t *testing.T) {
@@ -50,17 +50,17 @@ func Test{{.Kind}}Post(t *testing.T) {
 	ctx := h.NewAuthenticatedContext(account)
 
 	// POST responses per openapi spec: 201, 409, 500
-	dino := openapi.{{.Kind}}{
+	{{.KindLowerSingular}}Input := openapi.{{.Kind}}{
 
 	}
 
 	// 201 Created
-	{{.KindLowerSingular}}, resp, err := client.DefaultApi.ApiRhTrexV1{{.Kind}}sPost(ctx).{{.Kind}}(dino).Execute()
+	{{.KindLowerSingular}}Output, resp, err := client.DefaultApi.ApiRhTrexV1{{.Kind}}sPost(ctx).{{.Kind}}({{.KindLowerSingular}}Input).Execute()
 	Expect(err).NotTo(HaveOccurred(), "Error posting object:  %v", err)
 	Expect(resp.StatusCode).To(Equal(http.StatusCreated))
-	Expect(*{{.KindLowerSingular}}.Id).NotTo(BeEmpty(), "Expected ID assigned on creation")
-	Expect(*{{.KindLowerSingular}}.Kind).To(Equal("{{.Kind}}"))
-	Expect(*{{.KindLowerSingular}}.Href).To(Equal(fmt.Sprintf("/api/rh-trex/v1/{{.KindLowerPlural}}/%s", *{{.KindLowerSingular}}.Id)))
+	Expect(*{{.KindLowerSingular}}Output.Id).NotTo(BeEmpty(), "Expected ID assigned on creation")
+	Expect(*{{.KindLowerSingular}}Output.Kind).To(Equal("{{.Kind}}"))
+	Expect(*{{.KindLowerSingular}}Output.Href).To(Equal(fmt.Sprintf("/api/rh-trex/v1/{{.KindLowerPlural}}/%s", *{{.KindLowerSingular}}Output.Id)))
 
 	// 400 bad request. posting junk json is one way to trigger 400.
 	jwtToken := ctx.Value(openapi.ContextAccessToken)
@@ -81,17 +81,17 @@ func Test{{.Kind}}Patch(t *testing.T) {
 
 	// POST responses per openapi spec: 201, 409, 500
 
-	dino, err := h.Factories.New{{.Kind}}(h.NewID())
+	{{.KindLowerSingular}}Model, err := h.Factories.New{{.Kind}}(h.NewID())
     Expect(err).NotTo(HaveOccurred())
 
 	// 200 OK
-	{{.KindLowerSingular}}, resp, err := client.DefaultApi.ApiRhTrexV1{{.Kind}}sIdPatch(ctx, dino.ID).{{.Kind}}PatchRequest(openapi.{{.Kind}}PatchRequest{}).Execute()
+	{{.KindLowerSingular}}Output, resp, err := client.DefaultApi.ApiRhTrexV1{{.Kind}}sIdPatch(ctx, {{.KindLowerSingular}}Model.ID).{{.Kind}}PatchRequest(openapi.{{.Kind}}PatchRequest{}).Execute()
 	Expect(err).NotTo(HaveOccurred(), "Error posting object:  %v", err)
 	Expect(resp.StatusCode).To(Equal(http.StatusOK))
-	Expect(*{{.KindLowerSingular}}.Id).To(Equal(dino.ID))
-	Expect(*{{.KindLowerSingular}}.CreatedAt).To(BeTemporally("~", dino.CreatedAt))
-	Expect(*{{.KindLowerSingular}}.Kind).To(Equal("{{.Kind}}"))
-	Expect(*{{.KindLowerSingular}}.Href).To(Equal(fmt.Sprintf("/api/rh-trex/v1/{{.KindLowerPlural}}/%s", *{{.KindLowerSingular}}.Id)))
+	Expect(*{{.KindLowerSingular}}Output.Id).To(Equal({{.KindLowerSingular}}Model.ID))
+	Expect(*{{.KindLowerSingular}}Output.CreatedAt).To(BeTemporally("~", {{.KindLowerSingular}}Model.CreatedAt))
+	Expect(*{{.KindLowerSingular}}Output.Kind).To(Equal("{{.Kind}}"))
+	Expect(*{{.KindLowerSingular}}Output.Href).To(Equal(fmt.Sprintf("/api/rh-trex/v1/{{.KindLowerPlural}}/%s", *{{.KindLowerSingular}}Output.Id)))
 
 	jwtToken := ctx.Value(openapi.ContextAccessToken)
 	// 500 server error. posting junk json is one way to trigger 500.


### PR DESCRIPTION
# What
Removes 'dino' hardcoded references in favor of {{.KindLowerSingular}} in templates

# Why
Not all variables need to be called dino, makes it easier to read when creating a new entity