### PR TITLE
fix: when counting and search params are supplied should take into account where conditions

### DIFF
--- a/templates/generate-test.txt
+++ b/templates/generate-test.txt
@@ -141,6 +141,6 @@ func Test{{.Kind}}ListSearch(t *testing.T) {
 	list, _, err := client.DefaultApi.ApiRhTrexV1{{.Kind}}sGet(ctx).Search(search).Execute()
 	Expect(err).NotTo(HaveOccurred(), "Error getting {{.KindLowerSingular}} list: %v", err)
 	Expect(len(list.Items)).To(Equal(1))
-	Expect(list.Total).To(Equal(int32(20)))
+	Expect(list.Total).To(Equal(int32(1)))
 	Expect(*list.Items[0].Id).To(Equal({{.KindLowerPlural}}[0].ID))
 }

--- a/test/integration/dinosaurs_test.go
+++ b/test/integration/dinosaurs_test.go
@@ -179,7 +179,7 @@ func TestDinosaurListSearch(t *testing.T) {
 	list, _, err := client.DefaultApi.ApiRhTrexV1DinosaursGet(ctx).Search(search).Execute()
 	Expect(err).NotTo(HaveOccurred(), "Error getting dinosaur list: %v", err)
 	Expect(len(list.Items)).To(Equal(1))
-	Expect(list.Total).To(Equal(int32(20)))
+	Expect(list.Total).To(Equal(int32(1)))
 	Expect(*list.Items[0].Id).To(Equal(dinosaurs[0].ID))
 }
 


### PR DESCRIPTION
```
fix/count-should-consider-search
---
make test && make test-integration
CGO_ENABLED=1 GOEXPERIMENT=boringcrypto go install -ldflags="" ./cmd/trex
OCM_ENV=testing gotestsum --format short-verbose -- -p 1 -v  \
	./pkg/... \
	./cmd/...
EMPTY pkg/api
EMPTY pkg/api/openapi
EMPTY pkg/api/presenters
EMPTY pkg/auth
EMPTY pkg/client/ocm
PASS pkg/config.TestConfigReadStringFile (0.00s)
PASS pkg/config.TestConfigReadIntFile (0.00s)
PASS pkg/config.TestConfigReadBoolFile (0.00s)
PASS pkg/config.TestConfigReadQuotedFile (0.00s)
PASS pkg/config
PASS pkg/controllers.TestControllerFramework (0.00s)
PASS pkg/controllers
EMPTY pkg/dao
EMPTY pkg/dao/mocks
EMPTY pkg/db
EMPTY pkg/db/db_context
EMPTY pkg/db/db_session
EMPTY pkg/db/migrations
EMPTY pkg/db/mocks
EMPTY pkg/db/transaction
PASS pkg/errors.TestErrorFormatting (0.00s)
PASS pkg/errors.TestErrorFind (0.00s)
PASS pkg/errors
EMPTY pkg/handlers
EMPTY pkg/logger
PASS pkg/services.TestDinosaurFindBySpecies (0.00s)
PASS pkg/services.TestSQLTranslation (0.01s)
PASS pkg/services
EMPTY pkg/util
EMPTY cmd/trex
EMPTY cmd/trex/clone
PASS cmd/trex/environments.TestLoadServices (1.10s)
PASS cmd/trex/environments
EMPTY cmd/trex/migrate
EMPTY cmd/trex/servecmd
EMPTY cmd/trex/server
EMPTY cmd/trex/server/logging

DONE 10 tests in 5.034s
CGO_ENABLED=1 GOEXPERIMENT=boringcrypto go install -ldflags="" ./cmd/trex
OCM_ENV=testing gotestsum --format short-verbose -- -p 1 -ldflags -s -v -timeout 1h  \
		./test/integration
I0528 10:11:40.830775 2707777 framework.go:72] Initializing testing environment
I0528 10:11:41.933362 2707777 framework.go:151] Using Mock OCM Authz Client
I0528 10:11:41.933378 2707777 framework.go:176] Disabling Sentry error reporting
I0528 10:11:41.942160 2707777 api_server.go:145] Serving without TLS at localhost:8000
I0528 10:11:41.942202 2707777 healthcheck_server.go:56] Serving HealthCheck without TLS at localhost:8083
PASS test/integration.TestControllerRacing (2.81s)
PASS test/integration.TestDinosaurGet (1.24s)
PASS test/integration.TestDinosaurPost (1.07s)
PASS test/integration.TestDinosaurPatch (1.03s)
PASS test/integration.TestDinosaurPaging (1.18s)
PASS test/integration.TestDinosaurListSearch (1.25s)
PASS test/integration.TestUpdateDinosaurWithRacingRequests (1.19s)
PASS test/integration.TestUpdateDinosaurWithRacingRequests_WithoutLock (1.25s)
I0528 10:11:52.992797 2707777 api_server.go:151] Web server terminated
PASS test/integration (cached)

DONE 8 tests in 0.379
```