### PR TITLE
Changes made for documentation issues, TLS cert error and podman push issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,8 +301,10 @@ image: cmds
 	$(container_tool) build -t "$(external_image_registry)/$(image_repository):$(image_tag)" .
 
 .PHONY: push
-push: image
-	$(container_tool) push "$(external_image_registry)/$(image_repository):$(image_tag)"
+push:	\
+	image \
+	project
+	$(container_tool) push "$(external_image_registry)/$(image_repository):$(image_tag)" --tls-verify=false
 
 deploy-%: project %-template
 	$(oc) apply --filename="templates/$*-template.json" | egrep --color=auto 'configured|$$'
@@ -357,5 +359,5 @@ db/teardown:
 crc/login:
 	@echo "Logging into CRC"
 	@crc console --credentials -ojson | jq -r .clusterConfig.adminCredentials.password | oc login --username kubeadmin --insecure-skip-tls-verify=true https://api.crc.testing:6443
-	@oc whoami --show-token | $(container_tool) login --username kubeadmin --password-stdin "$(external_image_registry)"
+	@oc whoami --show-token | $(container_tool) login --username kubeadmin --password-stdin "$(external_image_registry)" --tls-verify=false
 .PHONY: crc/login

--- a/PREREQUISITES.md
+++ b/PREREQUISITES.md
@@ -1,0 +1,34 @@
+# Prerequisites
+
+TRex requires the following tools to be pre-installed:
+
+## crc
+
+`crc` stands for CodeReady Containers and is a tool to run containers. It manages a local OpenShift 4.x cluster, or an OKD cluster VM optimized for testing and development purposes.
+
+- **Purpose**: It is used for running OpenShift clusters locally.
+- **Installation**: Visit the [crc documentation](https://crc.dev/crc/).
+
+## Go
+
+`Go` is an open-source programming language that makes it easy to build simple, reliable, and efficient software.
+
+- **Purpose**: In our project, Go is required for building and running binaries required by TRex.
+- **Installation**: Install Go from the [official Go website](https://golang.org/dl/).
+
+## jq
+
+`jq` is a lightweight and flexible command-line JSON processor. It is used for JSON parsing and manipulation.
+
+- **Purpose**: It allows parsing of JSON outputs from commands. Additional information and documentation can be found on [DevDocs for jq](https://devdocs.io/jq/).
+- **Installation**: Follow the instructions on the [jq official website](https://jqlang.github.io/jq/).
+
+## ocm
+
+`ocm` stands for OpenShift Cluster Manager and is used for managing OpenShift clusters, including creation, deletion, and configuration.
+
+- **Purpose**: It is a CLI tool used for the managing Openshift clusters.
+- **Installation**: Refer to the [OCM documentation](https://github.com/openshift-online/ocm-cli).
+
+
+Make sure all these prerequisites are installed before running TRex.

--- a/PREREQUISITES.md
+++ b/PREREQUISITES.md
@@ -13,7 +13,7 @@ TRex requires the following tools to be pre-installed:
 
 `Go` is an open-source programming language that makes it easy to build simple, reliable, and efficient software.
 
-- **Purpose**: In our project, Go is required for building and running binaries required by TRex.
+- **Purpose**: In our project, Go is required for building and running the `trex` binary required by TRex.
 - **Installation**: Install Go from the [official Go website](https://golang.org/dl/).
 
 ## jq

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ framework with an upgrade path.
 
 ## Run for the first time
 
+Before running TRex for the first time, ensure the prerequisites are installed. For more detailed information on each prerequisite, refer to the [prerequisites](./PREREQUISITES.md) document.
+
+
 ### Make a build and run postgres
 
 ```sh


### PR DESCRIPTION
# Makefile: 
### Added "--tls-verify=FALSE" to podman push command and podman login
### Added a missing prerequisite to Makefile target (Image push fails if the ocm project doesnt exist, default project should not be used)

# PREREQUISITES.md
### Added necessary prereq tools, their purpose and official documentation links.

# README.md
### Added link to PREREQUISITES.md companion doc
