### PR TITLE
rhtrex parser github action

### DIFF
--- a/cmd/trex/environments/.github/workflows/rhtrex-parser.yml
+++ b/cmd/trex/environments/.github/workflows/rhtrex-parser.yml
@@ -1,0 +1,50 @@
+name: Parse T-Rex Files
+
+on:
+    schedule:
+      - cron: '0 0 * * 0'  # Runs at midnight every Sunday
+    workflow_dispatch:
+
+jobs:
+  find-trex-files:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        ref: main
+
+    - name: Find T-Rex files
+      id: find_files
+      run: |
+        # Find all files with 'trex' in their name, ignoring files that start with '.'
+        filename_matches=$(find . -type f -name '*trex*' ! -path './.*')
+
+        # Find all files with 'trex' in their content, ignoring files that start with '.'
+        content_matches=$(grep -rl 'trex' --exclude-dir='.*')
+
+        # Combine both results into a single list, removing duplicates
+        combined_results=$(echo -e "$filename_matches\n$content_matches" | sort -u | grep -v '^./\.')
+
+        # Format the combined results into a YAML array
+        formatted_results=$(echo "$combined_results" | awk '{print "- \"" $0 "\""}')
+
+        # Write the YAML array to a file
+        echo -e "$formatted_results" > trex_files.yaml
+
+        # Print the result to the log
+        echo "Files found:"
+        cat trex_files.yaml
+        
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v3
+      with:
+        signoff: true
+        branch: "trex-file-parser"
+        delete-branch: true
+        title: "Trex File Parser"
+        committer: GitHub <noreply@github.com>
+        author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+        labels: |
+          ok-to-test
+        reviewers: eemurphy, markturansky, gurnben


### PR DESCRIPTION
Creating an action that lists all files in rh-trex that include 'trex' in its name or contents. This is to be used for the Rh-Trex Software Template that helps devs create an app based on rh-trex's template.

Backstage's Software Templates are incapable of creating arrays or doing any shell scripting in general, but requires an array of files to look through to replace instances where 'trex' is written to the new app's name. So after discussion we have decided to attempt to create this action, and use the file it produces as the array necessary to go through to rename the code for the new app. 

JIRA: https://issues.redhat.com/browse/HYPBLD-325 
Software Template Location: https://gitlab.cee.redhat.com/service/software-templates-catalog

Signed-off-by: Erin Murphy <erinmurp@redhat.com>