### PR TITLE
OCM-18690 | fix: enhance clone with section in readme and fix test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,12 +231,16 @@ generate:
 	$(container_tool) cp $(OPENAPI_IMAGE_ID):/local/data/generated/openapi/openapi.go ./data/generated/openapi/openapi.go
 .PHONY: generate
 
-run: install
-	trex migrate
-	trex serve
+run: binary
+	./trex migrate
+	./trex serve
 .PHONY: run
 
-# Run Swagger and host the api docs
+run-no-auth: binary
+	./trex migrate
+	./trex serve --enable-authz=false --enable-jwt=false
+
+# Run Swagger nd host the api docs
 run/docs:
 	@echo "Please open http://localhost/"
 	docker run -d -p 80:8080 -e SWAGGER_JSON=/trex.yaml -v $(PWD)/openapi/rh-trex.yaml:/trex.yaml swaggerapi/swagger-ui

--- a/pkg/db/db_session/test.go
+++ b/pkg/db/db_session/test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	"github.com/lib/pq"
 
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
@@ -91,11 +92,11 @@ func resetDB(config *config.DatabaseConfig) error {
 	}
 
 	// Rebuild AMS DB
-	query := fmt.Sprintf("DROP DATABASE IF EXISTS %s", config.Name)
+	query := fmt.Sprintf("DROP DATABASE IF EXISTS %s", pq.QuoteIdentifier(config.Name))
 	if _, err := dbx.Exec(query); err != nil {
 		return fmt.Errorf("SQL failed to DROP database %s: %s", config.Name, err.Error())
 	}
-	query = fmt.Sprintf("CREATE DATABASE %s TEMPLATE template1", config.Name)
+	query = fmt.Sprintf("CREATE DATABASE %s TEMPLATE template1", pq.QuoteIdentifier(config.Name))
 	if _, err := dbx.Exec(query); err != nil {
 		return fmt.Errorf("SQL failed to CREATE database %s: %s", config.Name, err.Error())
 	}

--- a/scripts/generator.go
+++ b/scripts/generator.go
@@ -52,13 +52,13 @@ func getCmdDir() string {
 	if err != nil {
 		panic(err)
 	}
-	
+
 	for _, entry := range entries {
 		if entry.IsDir() {
 			return entry.Name()
 		}
 	}
-	
+
 	panic("No command directory found in cmd/")
 }
 
@@ -144,7 +144,7 @@ func main() {
 		if strings.EqualFold("generate-"+nm, "generate-openapi-kind") {
 			modifyOpenapi("openapi/openapi.yaml", fmt.Sprintf("openapi/openapi.%s.yaml", k.KindLowerPlural))
 		}
-		
+
 		// Add controller registration and presenter mappings after all templates are processed
 		if nm == "services" {
 			addControllerRegistration(k)
@@ -172,15 +172,15 @@ func toSnakeCase(s string) string {
 }
 
 type myWriter struct {
-	Repo                     string
-	Project                  string
-	Cmd                      string
-	Kind                     string
-	KindPlural               string
-	KindLowerPlural          string
-	KindLowerSingular        string
-	KindSnakeCasePlural      string
-	ID                       string
+	Repo                string
+	Project             string
+	Cmd                 string
+	Kind                string
+	KindPlural          string
+	KindLowerPlural     string
+	KindLowerSingular   string
+	KindSnakeCasePlural string
+	ID                  string
 }
 
 func modifyOpenapi(mainPath string, kindPath string) {
@@ -245,7 +245,7 @@ func writeAfterLine(path string, matchingLine string, lineToWrite string) {
 
 func addControllerRegistration(k myWriter) {
 	controllerFile := fmt.Sprintf("cmd/%s/server/controllers.go", k.Cmd)
-	
+
 	// Add controller registration
 	controllerRegistration := fmt.Sprintf(`
 	%sServices := env().Services.%s()
@@ -259,7 +259,7 @@ func addControllerRegistration(k myWriter) {
 		},
 	})
 `, k.KindLowerSingular, k.KindPlural, k.KindPlural, k.KindLowerSingular, k.KindLowerSingular, k.KindLowerSingular)
-	
+
 	// Insert before the return statement
 	matchingLine := `	return s`
 	writeBeforePattern(controllerFile, matchingLine, controllerRegistration)
@@ -270,17 +270,17 @@ func addPresenterMappings(k myWriter) {
 	kindFile := "pkg/api/presenters/kind.go"
 	kindMapping := fmt.Sprintf(`	case api.%s, *api.%s:
 		result = "%s"`, k.Kind, k.Kind, k.Kind)
-	
+
 	// Insert before the errors case
 	kindMatchingLine := `	case errors.ServiceError, *errors.ServiceError:
 		result = "Error"`
 	writeBeforePattern(kindFile, kindMatchingLine, kindMapping)
-	
-	// Add path mapping to presenters/path.go  
+
+	// Add path mapping to presenters/path.go
 	pathFile := "pkg/api/presenters/path.go"
 	pathMapping := fmt.Sprintf(`	case api.%s, *api.%s:
 		return "%s"`, k.Kind, k.Kind, k.KindSnakeCasePlural)
-	
+
 	// Insert before the errors case
 	pathMatchingLine := `	case errors.ServiceError, *errors.ServiceError:
 		return "errors"`


### PR DESCRIPTION
The original clone scripts has problems dealing hardcoded code. It caused confused `rh-trex` or `trex` left in cloned project. This PR will fix the clone issues.