### PR TITLE
Update openapi generator image and fix tests

### DIFF
--- a/Dockerfile.openapi
+++ b/Dockerfile.openapi
@@ -1,13 +1,7 @@
-FROM openapitools/openapi-generator-cli:v6.6.0
+FROM openapitools/openapi-generator-cli:v7.16.0
 
 RUN apt-get update
-RUN apt-get install -y make sudo git
-
-# Add sources to get golang 1.21 and skip time related release not valid until failures
-RUN echo "deb http://deb.debian.org/debian bookworm-backports main contrib non-free\ndeb-src http://deb.debian.org/debian bookworm-backports main contrib non-free" >> /etc/apt/sources.list
-RUN echo "Acquire::Check-Valid-Until \"false\";\nAcquire::Check-Date \"false\";" | cat > /etc/apt/apt.conf.d/10no--check-valid-until
-RUN apt-get update
-RUN apt-get install -y golang-1.21
+RUN apt-get install -y make sudo git golang-1.21
 
 RUN mkdir -p /local
 COPY . /local


### PR DESCRIPTION
1. Fix openapi generation (`make generate`)
 
OpenAPI artifact generation was failing with version `openapitools/openapi-generator-cli:v6.6.0`, updated to `v7.16.0`

2. Fix integration tests (`make test-integration`)
 
Integration tests failed for two reasons
- Openapi generator version change generates client api from `client.DefaultApi` to `client.DefaultAPI` on tests
- Flawed logic on tests because an optimization in the application code
  - Updates to a dinasour entity is not performed if value to change is the same as existing
  - The test counted invalid database operations

Assisted-by: claude

(Claude correctly identified the flaw in the test)
